### PR TITLE
Ruby 2.2.0+ is required

### DIFF
--- a/salt_client.gemspec
+++ b/salt_client.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.2.0'
+
   spec.add_dependency "unirest", "~> 1.1"
 
   spec.add_development_dependency "bundler", "~> 1.8"


### PR DESCRIPTION
This is due to hash syntax not being available until 2.2
See the hash [here](https://github.com/arcade/salt_client/commit/b90951a9f55f3ad77fed71bd33faf5ed9538d7ac#diff-056d105f872fe8579c6d8f3284b97683R25)
